### PR TITLE
Change doxygen settings to print all warnings before failing.

### DIFF
--- a/static/api-docs/next/doxygen/Doxyfile
+++ b/static/api-docs/next/doxygen/Doxyfile
@@ -801,7 +801,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which

--- a/static/api-docs/next/doxygen/Doxyfile-ci
+++ b/static/api-docs/next/doxygen/Doxyfile-ci
@@ -801,7 +801,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = FAIL_ON_WARNINGS
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which


### PR DESCRIPTION
Changes the doxyfile settings for `WARN_AS_ERROR` from `YES` to `FAIL_ON_WARNINGS`. This option also fails when a warnings i encountered, but fully processes the documentation instead of fast failing to allow all warnings to be discovered in a single run.